### PR TITLE
Require python3

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,9 +4,11 @@
 # To use it, call Python at ./python-env/bin/python.
 
 # Test if everything is available
+python3 --version >/dev/null 2>&1 || missing=$missing"[bootstrap.sh] Python3 is required but it's not installed.\n"
 virtualenv --version >/dev/null 2>&1 || missing=$missing"[bootstrap.sh] Python virtualenv is required but it's not installed.\n"
 gcc --version >/dev/null 2>&1 || missing=$missing"[bootstrap.sh] GCC is required but it's not installed.\n"
 git --version >/dev/null 2>&1 || missing=$missing"[bootstrap.sh] GIT is required but it's not installed.\n"
+
 
 # Report errors if any
 if [[ -n "$missing" ]]; then
@@ -15,5 +17,8 @@ if [[ -n "$missing" ]]; then
     exit 1
 fi
 
-virtualenv python_env
+## find python3 interpreter
+
+pypath=`which python3`
+virtualenv --python=$pypath python_env
 ./python_env/bin/pip install pyyaml numpy biopython psutil cpython scipy deepdiff tqdm

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -17,8 +17,9 @@ if [[ -n "$missing" ]]; then
     exit 1
 fi
 
-## find python3 interpreter
 
+# get the python3 interpreter, virtualenv uses python2 by default
 pypath=`which python3`
+
 virtualenv --python=$pypath python_env
 ./python_env/bin/pip install pyyaml numpy biopython psutil cpython scipy deepdiff tqdm


### PR DESCRIPTION
Ich habe mal ins bootstrap.sh eine Abfrage nach python3 eingebaut
und virtualenv den python3 interpreter übergeben, sons gibt es beim
ausführen einen ERROR.

Falls dass so gewünscht ist, bitte mergen!

Virtualenv benutzt standardmäßig den python2 interpreter...was für die python3-basierte uap version irgendwie doof ist.