### PR TITLE
Require python3

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,9 +4,11 @@
 # To use it, call Python at ./python-env/bin/python.
 
 # Test if everything is available
+python3 --version >/dev/null 2>&1 || missing=$missing"[bootstrap.sh] Python3 is required but it's not installed.\n"
 virtualenv --version >/dev/null 2>&1 || missing=$missing"[bootstrap.sh] Python virtualenv is required but it's not installed.\n"
 gcc --version >/dev/null 2>&1 || missing=$missing"[bootstrap.sh] GCC is required but it's not installed.\n"
 git --version >/dev/null 2>&1 || missing=$missing"[bootstrap.sh] GIT is required but it's not installed.\n"
+
 
 # Report errors if any
 if [[ -n "$missing" ]]; then
@@ -15,5 +17,8 @@ if [[ -n "$missing" ]]; then
     exit 1
 fi
 
-virtualenv python_env
+## find python3 interpreter
+
+pypath=`which python3`
+virtualenv --python=$pypath python_env
 ./python_env/bin/pip install pyyaml numpy biopython psutil cpython scipy deepdiff tqdm

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -17,8 +17,9 @@ if [[ -n "$missing" ]]; then
     exit 1
 fi
 
-## find python3 interpreter
 
+# get the python3 interpreter, virtualenv uses python2 by default
 pypath=`which python3`
+
 virtualenv --python=$pypath python_env
 ./python_env/bin/pip install pyyaml numpy biopython psutil cpython scipy deepdiff tqdm

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+exit
+
 # This script creates a virtual Python environment in ./python-env with all required libraries set up.
 # To use it, call Python at ./python-env/bin/python.
 
@@ -21,5 +23,8 @@ fi
 # get the python3 interpreter, virtualenv uses python2 by default
 pypath=`which python3`
 
+# get the uap directory
+dir=`dirname $0`
+
 virtualenv --python=$pypath python_env
-./python_env/bin/pip install pyyaml numpy biopython psutil cpython scipy deepdiff tqdm
+$dir/python_env/bin/pip install pyyaml numpy biopython psutil cpython scipy deepdiff tqdm

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -25,5 +25,5 @@ pypath=`which python3`
 # get the uap directory
 dir=`dirname $0`
 
-virtualenv --python=$pypath python_env
+virtualenv --python=$pypath $dir/python_env
 $dir/python_env/bin/pip install pyyaml numpy biopython psutil cpython scipy deepdiff tqdm

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-exit
 
 # This script creates a virtual Python environment in ./python-env with all required libraries set up.
 # To use it, call Python at ./python-env/bin/python.


### PR DESCRIPTION
Ich habe mal ins bootstrap.sh eine Abfrage nach python3 eingebaut
und virtualenv den python3 interpreter übergeben, sons gibt es beim
ausführen einen ERROR.

Falls dass so OK ist, bitte mergen!

Virtualenv benutzt standardmäßig den python2 interpreter...was für die python3-basierte uap version irgendwie doof ist.

Des Weiteren wird virtualenv jetzt immer in das geclonte repo installiert, egal von wo man das bootstraph.sh script aufruft.
Das macht die Installation, z.B. im singularity container einfacher.