### PR TITLE
add missing tools

### DIFF
--- a/singularity_container/uap-sc.def
+++ b/singularity_container/uap-sc.def
@@ -41,8 +41,10 @@ Stage: build
     # also in einem conda install befehl oder gleich beim conda create
     conda create --yes --name uap_python3_v1.0 -c conda-forge -c bioconda -c r -c anaconda \
 	python cufflinks=2.2.1 fastqc=0.11.9 fastx_toolkit=0.0.14 hisat2=2.2.0 htseq=0.12.4 \
-	pigz=2.3.4 samtools=1.9 stringtie=2.1.2 cutadapt=2.10 virtualenv=20.0.20 graphviz=2.42.3
-    
+	pigz=2.3.4 samtools=1.9 stringtie=2.1.2 cutadapt=2.10 virtualenv=20.0.20 graphviz=2.42.3 \
+	adapterremoval=2.3.1 salmon=1.3.0 bwa=0.7.17 bowtie2=2.4.2 ucsc-fetchchromsizes=377 \
+	segemehl=0.3.4 preseq=2.0.3 picard=2.18.7 kallisto=0.46.2 star=2.7.6a
+	   
     conda env export --name uap_python3_v1.0 > uap_python3_v1.0.conda_env.yaml
 
     # activate the conda environment
@@ -115,3 +117,13 @@ EOF
     htseq                     0.12.4
     samtools                  1.9
     stringtie                 2.1.2
+    adapterremoval            2.3.1
+    salmon                    1.3.0
+    bwa                       0.7.17
+    bowtie2                   2.4.2
+    ucsc-fetchchromsizes      377
+    segemehl                  0.3.4
+    preseq                    2.0.3
+    picard                    2.18.7
+    kallisto                  0.46.2
+    star                      2.7.6a


### PR DESCRIPTION
add tools for the example configurations in the singularity container definition file
add adapterremoval, salmon, bwa, bowtie2, fetchschromsizes, segemehl, preseq, picard, kallisto, star

still missing tools: tophat2, macs2